### PR TITLE
Modify : Vibrate Control API for Scene Change System

### DIFF
--- a/Assets/00. Workspace/03. Park/VibrateTest/VibrateTestScene.unity
+++ b/Assets/00. Workspace/03. Park/VibrateTest/VibrateTestScene.unity
@@ -1779,7 +1779,7 @@ GameObject:
   - component: {fileID: 1295393736}
   m_Layer: 0
   m_Name: XR Origin
-  m_TagString: Untagged
+  m_TagString: XR Origin
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/02. Scripts/Global Function/VibrateControl.cs
+++ b/Assets/02. Scripts/Global Function/VibrateControl.cs
@@ -24,8 +24,40 @@ public class VibrateControl : MonoBehaviour
         DontDestroyOnLoad(this);
     }
 
-    [SerializeField] private ActionBasedController rightController;
-    [SerializeField] private ActionBasedController leftController;
+    private ActionBasedController rightController;
+    private ActionBasedController leftController;
+
+    private GameObject XROrigin;
+
+    /// <summary>
+    /// 게임이 실행됐을 때 존재하는 XR Origin의 컨트롤러를 사용 가능하도록 연결합니다.
+    /// </summary>
+    private void Start()
+    {
+        InitializeController();
+    }
+
+    /// <summary>
+    /// 맨 처음 씬에 들어오거나 다른 씬으로 이동하여 새로운 XR Origin이 존재하는 경우
+    /// 해당 XR Origin의 컨트롤러를 사용 가능하도록 연결합니다.
+    /// </summary>
+    public void InitializeController()
+    {
+        XROrigin = GameObject.FindWithTag("XR Origin");
+
+        Transform[] originChildrens = XROrigin.GetComponentsInChildren<Transform>();
+        foreach (Transform originChild in originChildrens)
+        {
+            if (originChild.name == "RightHand Controller")
+            {
+                rightController = originChild.GetComponent<ActionBasedController>();
+            }
+            else if (originChild.name == "LeftHand Controller")
+            {
+                leftController = originChild.GetComponent<ActionBasedController>();
+            }
+        }
+    }
 
     /// <summary>
     /// 오른쪽 컨트롤러가 활성화된 상태인 경우 오른쪽 컨트롤러에 진동을 재생합니다.

--- a/Assets/04. Models/Dial(Fixed).fbx.meta
+++ b/Assets/04. Models/Dial(Fixed).fbx.meta
@@ -1,0 +1,106 @@
+fileFormatVersion: 2
+guid: 97d8e179a110add49a64895f3c863703
+ModelImporter:
+  serializedVersion: 21300
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 1
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documents/API/API 문서.md
+++ b/Documents/API/API 문서.md
@@ -23,7 +23,7 @@ User Interaction을 통해 화살표를 따라 각 씬으로 이동 가능하다
 
 여러 씬에서 중복적으로 사용되는 기능들이다.
 
-## AbstarctSceneManager
+## AbstractSceneManager
 
 ---
 
@@ -356,6 +356,14 @@ XR Origin의 ActionBasedController와 연결하여 해당 컨트롤러에 원하
 
 - private ActionBasedController leftController
     - XR Origin - Camera Offset 내의 LeftHand Controller 오브젝트를 참조해 불러오는 변수
+
+- private GameObject XROrigin
+    - 새로운/이동한 씬에 존재하는 XR Origin 오브젝트를 참조하여 저장하기 위한 변수
+
+- public void InitializeController()
+    - 맨 처음 게임 실행 후 씬에 들어오거나, 다른 씬으로 이동하였을 때 새로운 Origin이 존재하여 업데이트가 필요한 경우에 사용하는 메소드
+    - 해당 씬의 새로운 XR Origin 객체를 찾아 Camera Offset 안의 LeftHand Controller와 RightHand Controller를 인스턴스와 연결해줌
+    - foreach 문을 통해 XR Origin의 모든 자식 객체들에 접근하여 탐색
 
 - public IEnumerator CustomVibrateRight(float amplitude, float duration)
     - 오른쪽 컨트롤러가 활성화된 상태인 경우 오른쪽 컨트롤러에 진동을 재생하는 코루틴 함수

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - XR Origin
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
#32 의 일환입니다.

- 원래 Vibrate Control API에 쓰이는 VR 컨트롤러 컴포넌트는 SerializeField로 인스펙터 상에서 연결을 해줬었습니다.
- 로비 씬과 씬 전환 API를 개발하던 중, 각 씬에 XR Origin이 따로 존재할 경우 씬 이동 시에 진동을 관할하게 될 Vibrate Controller 오브젝트가 새로운 XR Origin의 컨트롤러를 연결받지 못하고 진동 시스템을 사용할 수 없을 것이라 판단하였습니다.
- 이에 씬 전환 API의 수월한 개발을 위해 Vibrate Control API가 씬을 이동할 때마다 그 씬에 있는 새로운(혹은 기존의) XR Origin에 존재하는 각 컨트롤러를 연결받을 수 있는 메소드를 만들었습니다.
- 메소드가 추가됨에 따라, [기술문서](https://www.notion.so/VR-fd5c155dad6447468978faffcdb4ca4c) 역시 업데이트하였습니다.